### PR TITLE
Create new client instance for each API request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 TARGETS=darwin linux windows
 WEBSITE_REPO=github.com/hashicorp/terraform-website
-PKG_NAME=shopify
+PKG_NAME=Shopify
 
 default: build fmtcheck staticcheck errcheck
 
@@ -42,12 +42,12 @@ fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 staticcheck:
-	@printf $(COLOR) "Run static check..."
+	@printf $(COLOR) "Run static check...\n"
 	@GO111MODULE=off go get -u honnef.co/go/tools/cmd/staticcheck
 	@staticcheck ./...
 
 errcheck:
-	@printf $(COLOR) "Run error check..."
+	@printf $(COLOR) "Run error check...\n"
 	@GO111MODULE=off go get -u github.com/kisielk/errcheck
 	@errcheck ./...
 

--- a/shopify/provider.go
+++ b/shopify/provider.go
@@ -35,7 +35,7 @@ func Provider() *schema.Provider {
 func providerConfigure(
 	ctx context.Context,
 	d *schema.ResourceData,
-) (client interface{}, diags diag.Diagnostics) {
+) (config interface{}, diags diag.Diagnostics) {
 	shopifyDomain := d.Get("domain").(string)
 	shopifyAccessToken := d.Get("access_token").(string)
 	if shopifyDomain == "" || shopifyAccessToken == "" {
@@ -43,10 +43,10 @@ func providerConfigure(
 		return
 	}
 
-	config := Config{
+	config = Config{
 		ShopifyDomain:      shopifyDomain,
 		ShopifyAccessToken: shopifyAccessToken,
 	}
-	client = config.NewClient()
+
 	return
 }

--- a/shopify/resource_shopify_webhook.go
+++ b/shopify/resource_shopify_webhook.go
@@ -28,7 +28,6 @@ func resourceShopifyWebhook() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"format": {
 				Type:     schema.TypeString,
 				Default:  "json",
@@ -99,7 +98,9 @@ func resourceShopifyWebhookCreate(
 		PrivateMetafieldNamespaces: privateMetafieldNamespaces,
 	}
 
-	client := meta.(*shopify.Client)
+	config := meta.(Config)
+	client := config.NewClient()
+
 	webhook, _, err := client.Webhooks.Create(params)
 	if err != nil {
 		return diag.Errorf("could not create Shopify webhook: %s", err)
@@ -115,7 +116,7 @@ func resourceShopifyWebhookCreate(
 	_ = d.Set("metafield_namespaces", webhook.MetafieldNamespaces)
 	_ = d.Set("private_metafield_namespaces", webhook.PrivateMetafieldNamespaces)
 
-	return nil
+	return resourceShopifyWebhookRead(ctx, d, meta)
 }
 
 func resourceShopifyWebhookUpdate(
@@ -154,7 +155,9 @@ func resourceShopifyWebhookUpdate(
 		PrivateMetafieldNamespaces: privateMetafieldNamespaces,
 	}
 
-	client := meta.(*shopify.Client)
+	config := meta.(Config)
+	client := config.NewClient()
+
 	webhook, _, err := client.Webhooks.Update(d.Id(), params)
 	if err != nil {
 		return diag.Errorf("could not update Shopify webhook: %s", err)
@@ -168,7 +171,7 @@ func resourceShopifyWebhookUpdate(
 	_ = d.Set("metafield_namespaces", webhook.MetafieldNamespaces)
 	_ = d.Set("private_metafield_namespaces", webhook.PrivateMetafieldNamespaces)
 
-	return nil
+	return resourceShopifyWebhookRead(ctx, d, meta)
 }
 
 func resourceShopifyWebhookRead(
@@ -176,7 +179,9 @@ func resourceShopifyWebhookRead(
 	d *schema.ResourceData,
 	meta interface{},
 ) diag.Diagnostics {
-	client := meta.(*shopify.Client)
+	config := meta.(Config)
+	client := config.NewClient()
+
 	webhook, resp, err := client.Webhooks.Read(d.Id())
 	if resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] Removing webhook ID='%s' from state because it no longer exists in Shopify", d.Id())
@@ -203,7 +208,9 @@ func resourceShopifyWebhookDelete(
 	d *schema.ResourceData,
 	meta interface{},
 ) diag.Diagnostics {
-	client := meta.(*shopify.Client)
+	config := meta.(Config)
+	client := config.NewClient()
+
 	_, err := client.Webhooks.Delete(d.Id())
 	if err != nil {
 		return diag.Errorf("could not delete Shopify webhook: %s", err)


### PR DESCRIPTION
Since the [sling](https://github.com/dghubble/sling) client is
mutable, manipulating URL's when dealing with multiple API calls
produced unexpected behaviour (e.g. resources were getting mixed
up). This was solved by creating a brand new client instance for each
API request, so that each URL was independent from any previous one.