### PR TITLE
Add api_version option to provider

### DIFF
--- a/shopify/config.go
+++ b/shopify/config.go
@@ -7,8 +7,9 @@ import (
 type Config struct {
 	ShopifyDomain      string
 	ShopifyAccessToken string
+	ShopifyApiVersion  string
 }
 
 func (c *Config) NewClient() *shopify.Client {
-	return shopify.NewClient(c.ShopifyDomain, c.ShopifyAccessToken)
+	return shopify.NewClient(c.ShopifyDomain, c.ShopifyAccessToken, c.ShopifyApiVersion)
 }

--- a/shopify/internal/client/client.go
+++ b/shopify/internal/client/client.go
@@ -11,7 +11,7 @@ type Client struct {
 	Webhooks *WebhookService
 }
 
-func NewClient(shopifyDomain string, shopifyAccessToken string) *Client {
+func NewClient(shopifyDomain string, shopifyAccessToken string, apiVersion string) *Client {
 	baseUrl := fmt.Sprintf("https://%s.myshopify.com/", shopifyDomain)
 	base := sling.New().Base(
 		baseUrl,
@@ -25,6 +25,6 @@ func NewClient(shopifyDomain string, shopifyAccessToken string) *Client {
 
 	return &Client{
 		sling:    base,
-		Webhooks: newWebhookService(base),
+		Webhooks: newWebhookService(base, apiVersion),
 	}
 }

--- a/shopify/internal/client/webhook.go
+++ b/shopify/internal/client/webhook.go
@@ -15,9 +15,11 @@ type WebhookService struct {
 	sling *sling.Sling
 }
 
-func newWebhookService(sling *sling.Sling) *WebhookService {
+func newWebhookService(sling *sling.Sling, apiVersion string) *WebhookService {
+	apiPath := fmt.Sprintf("%s/", apiVersion)
+
 	return &WebhookService{
-		sling: sling.New().Path("admin/").Path("webhooks/"),
+		sling: sling.New().Path("admin/").Path("api/").Path(apiPath).Path("webhooks/"),
 	}
 }
 

--- a/shopify/provider.go
+++ b/shopify/provider.go
@@ -22,6 +22,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("SHOPIFY_ACCESS_TOKEN", nil),
 				Description: "Shopify access token",
 			},
+			"api_version": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SHOPIFY_API_VERSION", nil),
+				Description: "Shopify API version",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -38,6 +44,7 @@ func providerConfigure(
 ) (config interface{}, diags diag.Diagnostics) {
 	shopifyDomain := d.Get("domain").(string)
 	shopifyAccessToken := d.Get("access_token").(string)
+	shopifyApiVersion := d.Get("api_version").(string)
 	if shopifyDomain == "" || shopifyAccessToken == "" {
 		diags = diag.Errorf("Please specify both 'domain' and 'access_token'")
 		return
@@ -46,6 +53,7 @@ func providerConfigure(
 	config = Config{
 		ShopifyDomain:      shopifyDomain,
 		ShopifyAccessToken: shopifyAccessToken,
+		ShopifyApiVersion:  shopifyApiVersion,
 	}
 
 	return


### PR DESCRIPTION
Some webhook topics are not available in older versions of the API, so I added an `api_version` config to the provider to allow the API version to be specified.